### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Features
 * PDF-Reports (very simple and easy to-modify)
 * Responsive design -> getbootstrap.com
 * Workflows attached to models
-  - easy configureable as classes (Workflow, states and transitions)
+  - easy configurable as classes (Workflow, states and transitions)
   - custom functions for transitions
   - integrated into the BMF (i.e you can delete or update a model instance only if the State allows you to do so)
 * Each option should be activated and deactivated in die model definition (how needs to append files or write comments to a tax-model?)


### PR DESCRIPTION
@django-bmf, I've corrected a typographical error in the documentation of the [django-bmf](https://github.com/django-bmf/django-bmf) project. Specifically, I've changed configureable to configurable. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.